### PR TITLE
Concept usage

### DIFF
--- a/src/golomb.h
+++ b/src/golomb.h
@@ -33,14 +33,14 @@
 namespace pg::golomb
 {
 
-template<typename InputIt>
-concept integral_iterator = std::integral< typename std::iterator_traits< InputIt >::value_type > && std::input_iterator<InputIt>;
-
-template<typename InputIt>
-concept unsigned_integral_iterator = std::unsigned_integral< typename std::iterator_traits< InputIt >::value_type > && std::input_iterator<InputIt>;
-
 namespace detail
 {
+
+template<typename InputIt>
+concept integral_iterator = ::std::integral< typename ::std::iterator_traits< InputIt >::value_type > && ::std::input_iterator<InputIt>;
+
+template<typename InputIt>
+concept unsigned_integral_iterator = ::std::unsigned_integral< typename ::std::iterator_traits< InputIt >::value_type > && ::std::input_iterator<InputIt>;
 
 template< std::signed_integral SignedT >
 auto to_unsigned( SignedT s )
@@ -191,7 +191,7 @@ public:
 };
 
 template< std::unsigned_integral OutputDataT = uint8_t,
-          integral_iterator InputIt,
+          pg::golomb::detail::integral_iterator InputIt,
           typename OutputIt >
 requires std::output_iterator<OutputIt, OutputDataT>
 constexpr auto encode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )
@@ -309,7 +309,7 @@ public:
 };
 
 template< std::integral OutputValueT,
-          unsigned_integral_iterator InputIt,
+          pg::golomb::detail::unsigned_integral_iterator InputIt,
           typename OutputIt >
 requires std::output_iterator<OutputIt, OutputValueT>
 constexpr auto decode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )

--- a/src/golomb.h
+++ b/src/golomb.h
@@ -33,11 +33,16 @@
 namespace pg::golomb
 {
 
+template<typename InputIt>
+concept integral_iterator = std::integral< typename std::iterator_traits< InputIt >::value_type >;
+
+template<typename InputIt>
+concept unsigned_integral_iterator = std::unsigned_integral< typename std::iterator_traits< InputIt >::value_type >;
+
 namespace detail
 {
 
-template< typename SignedT >
-requires std::signed_integral< SignedT >
+template< std::signed_integral SignedT >
 auto to_unsigned( SignedT s )
 {
     using UnsignedT = typename std::make_unsigned< SignedT >::type;
@@ -50,15 +55,13 @@ auto to_unsigned( SignedT s )
     return static_cast< UnsignedT >( s << 1 );
 }
 
-template< typename UnsignedT >
-requires std::unsigned_integral< UnsignedT >
+template< std::unsigned_integral UnsignedT >
 auto to_unsigned( UnsignedT u )
 {
     return u;
 }
 
-template< typename SignedT >
-requires std::signed_integral< SignedT >
+template< std::signed_integral SignedT >
 auto to_integral( std::unsigned_integral auto u )
 {
     using UnsignedT = typename std::make_unsigned< SignedT >::type;
@@ -72,8 +75,7 @@ auto to_integral( std::unsigned_integral auto u )
     return static_cast< SignedT >( U >> 1 );
 }
 
-template< typename UnsignedT >
-requires std::unsigned_integral< UnsignedT >
+template< std::unsigned_integral UnsignedT >
 auto to_integral( std::unsigned_integral auto u )
 {
     return static_cast< UnsignedT >( u );
@@ -81,8 +83,7 @@ auto to_integral( std::unsigned_integral auto u )
 
 }
 
-template< typename OutputIt, typename OutputDataT = uint8_t >
-requires std::unsigned_integral< OutputDataT >
+template< typename OutputIt, std::unsigned_integral OutputDataT = uint8_t >
 class encoder
 {
     static constexpr auto output_digits = std::numeric_limits< OutputDataT >::digits;
@@ -96,26 +97,25 @@ class encoder
     int         encoded_count;
 
 public:
-    encoder( OutputIt output, size_t k = 0u ) noexcept
-        : output( output )
-        , k( k )
-        , base( 1u << k )
-        , zeros_threshold( 1 + k )
+    encoder( OutputIt output_in, size_t k_in = 0u ) noexcept
+        : output( output_in )
+        , k( k_in)
+        , base( 1u << k_in)
+        , zeros_threshold( 1 + k_in)
         , encoded( static_cast< OutputDataT>( 0u ) )
         , encoded_count( 0 )
     {}
 
-    template< typename InputValueT >
-    requires std::integral< InputValueT >
+    template< std::integral InputValueT >
     OutputIt push( InputValueT x )
     {
         using UnsignedInputValueT = typename std::make_unsigned< InputValueT >::type;
         using CommonT             = typename std::common_type< UnsignedInputValueT, OutputDataT >::type;
 
-        constexpr auto input_digits  = std::numeric_limits< UnsignedInputValueT >::digits;
-        constexpr auto input_mask    = std::numeric_limits< UnsignedInputValueT >::max();
+        static constexpr auto input_digits  = std::numeric_limits< UnsignedInputValueT >::digits;
+        static constexpr auto input_mask    = std::numeric_limits< UnsignedInputValueT >::max();
 
-        const auto overflow_threshold = std::numeric_limits< UnsignedInputValueT >::max() - ( static_cast< OutputDataT >( base ) );
+        const auto overflow_threshold = input_mask - ( static_cast< OutputDataT >( base ) );
         const auto max_zeros          = input_digits - k;
 
         const auto u         = detail::to_unsigned( x );
@@ -123,13 +123,13 @@ public:
         const auto value     = static_cast< UnsignedInputValueT >( u + base );
         const int  bit_width = static_cast< int >( std::bit_width( value ) ); // cast is a workaround for unresolved defect report in GCC/libc++
         const int  width     = overflow ? input_digits : bit_width;
-        const int  zeros     = overflow ? max_zeros : width - zeros_threshold;
+        const int  zeros     = overflow ? max_zeros : (width - zeros_threshold);
 
         encoded_count += zeros;
         for( ; encoded_count >= output_digits ; encoded_count -= output_digits )
         {
             *output++ = encoded;
-            encoded   = 0;
+            encoded   = 0u;
         }
 
         if( overflow )
@@ -189,11 +189,9 @@ public:
     }
 };
 
-template< typename OutputDataT = uint8_t,
-          typename InputIt,
+template< std::unsigned_integral OutputDataT = uint8_t,
+          integral_iterator InputIt,
           typename OutputIt >
-requires std::integral< typename std::iterator_traits< InputIt >::value_type > &&
-         std::unsigned_integral< OutputDataT >
 constexpr auto encode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )
 {
     using ValueT = typename std::iterator_traits< InputIt >::value_type;
@@ -208,8 +206,7 @@ constexpr auto encode( InputIt input, InputIt last, OutputIt output, size_t k = 
     return e.flush();
 }
 
-template< typename OutputIt, typename OutputValueT >
-requires std::integral< OutputValueT >
+template< typename OutputIt, std::integral OutputValueT >
 class decoder
 {
     using UnsignedOutputValueT = typename std::make_unsigned< OutputValueT >::type;
@@ -224,7 +221,7 @@ class decoder
     UnsignedOutputValueT output_buffer;
     int                  digits;
     
-    enum { scan_zeros, decode } state = scan_zeros;
+    enum class scan_state { scan_zeros, decode } state = scan_zeros;
 
 public:
     decoder( OutputIt output, size_t k = 0u )
@@ -234,11 +231,10 @@ public:
         , initial_digits( 1 + static_cast< int >( k ) )
         , output_buffer( 0u )
         , digits( initial_digits )
-        , state( scan_zeros )
+        , state(scan_state::scan_zeros )
     {}
 
-    template< typename InputDataT >
-    requires std::unsigned_integral< InputDataT >
+    template< std::unsigned_integral InputDataT >
     OutputIt push( InputDataT input )
     {
         using CommonT = typename std::common_type< InputDataT, UnsignedOutputValueT >::type;
@@ -249,7 +245,7 @@ public:
         int input_consumed = 0;
         while( input_consumed != input_digits )
         {
-            if( state == scan_zeros )
+            if( state == scan_state::scan_zeros )
             {
                 const auto n = std::countl_zero( input );
 
@@ -258,7 +254,7 @@ public:
 
                 if( input )
                 {
-                    state = decode;
+                    state = scan_state::decode;
                 }
             }
             else    // decode
@@ -292,7 +288,7 @@ public:
                     *output++     = detail::to_integral< OutputValueT >( output_buffer - base );
                     output_buffer = 0u;
                     digits        = initial_digits;
-                    state         = scan_zeros;
+                    state         = scan_state::scan_zeros;
                 }
             }
         }
@@ -304,17 +300,15 @@ public:
     {
         output_buffer = 0u;
         digits        = initial_digits;
-        state         = scan_zeros;
+        state         = scan_state::scan_zeros;
         
         return output;
     }
 };
 
-template< typename OutputValueT,
-          typename InputIt,
+template< std::integral OutputValueT,
+          unsigned_integral_iterator InputIt,
           typename OutputIt >
-requires std::unsigned_integral< typename std::iterator_traits< InputIt >::value_type > &&
-         std::integral< OutputValueT >
 constexpr auto decode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )
 {
     decoder< OutputIt, OutputValueT > d( output, k );

--- a/src/golomb.h
+++ b/src/golomb.h
@@ -190,7 +190,7 @@ public:
 };
 
 template< std::unsigned_integral OutputDataT = uint8_t,
-          pg::golomb::detail::integral_input_iterator InputIt,
+          detail::integral_input_iterator InputIt,
           typename OutputIt >
 requires std::output_iterator<OutputIt, OutputDataT>
 constexpr auto encode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )
@@ -308,7 +308,7 @@ public:
 };
 
 template< std::integral OutputValueT,
-          pg::golomb::detail::unsigned_integral_input_iterator InputIt,
+          detail::unsigned_integral_input_iterator InputIt,
           typename OutputIt >
 requires std::output_iterator<OutputIt , OutputValueT>
 constexpr auto decode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )

--- a/src/golomb.h
+++ b/src/golomb.h
@@ -37,10 +37,10 @@ namespace detail
 {
 
 template<typename InputIt>
-concept integral_iterator = ::std::integral< typename ::std::iterator_traits< InputIt >::value_type > && ::std::input_iterator<InputIt>;
+concept integral_iterator = std::integral< typename std::iterator_traits< InputIt >::value_type > && std::input_iterator<InputIt>;
 
 template<typename InputIt>
-concept unsigned_integral_iterator = ::std::unsigned_integral< typename ::std::iterator_traits< InputIt >::value_type > && ::std::input_iterator<InputIt>;
+concept unsigned_integral_iterator = std::unsigned_integral< typename std::iterator_traits< InputIt >::value_type > && std::input_iterator<InputIt>;
 
 template< std::signed_integral SignedT >
 auto to_unsigned( SignedT s )
@@ -223,7 +223,7 @@ class decoder
     UnsignedOutputValueT output_buffer;
     int                  digits;
     
-    enum class scan_state { scan_zeros, decode } state = scan_zeros;
+    enum class scan_state { scan_zeros, decode } state = scan_state::scan_zeros;
 
 public:
     decoder( OutputIt output, size_t k = 0u )

--- a/src/golomb.h
+++ b/src/golomb.h
@@ -98,11 +98,11 @@ class encoder
     int         encoded_count;
 
 public:
-    encoder( OutputIt output_in, size_t k_in = 0u ) noexcept
-        : output( output_in )
-        , k( k_in)
-        , base( 1u << k_in)
-        , zeros_threshold( 1 + k_in)
+    encoder( OutputIt output, size_t k = 0u ) noexcept
+        : output( output )
+        , k( k )
+        , base( 1u << k )
+        , zeros_threshold( 1 + k )
         , encoded( static_cast< OutputDataT>( 0u ) )
         , encoded_count( 0 )
     {}
@@ -116,7 +116,7 @@ public:
         static constexpr auto input_digits  = std::numeric_limits< UnsignedInputValueT >::digits;
         static constexpr auto input_mask    = std::numeric_limits< UnsignedInputValueT >::max();
 
-        const auto overflow_threshold = input_mask - ( static_cast< OutputDataT >( base ) );
+        const auto overflow_threshold = input_mask - static_cast< OutputDataT >( base );
         const auto max_zeros          = input_digits - k;
 
         const auto u         = detail::to_unsigned( x );
@@ -124,7 +124,7 @@ public:
         const auto value     = static_cast< UnsignedInputValueT >( u + base );
         const int  bit_width = static_cast< int >( std::bit_width( value ) ); // cast is a workaround for unresolved defect report in GCC/libc++
         const int  width     = overflow ? input_digits : bit_width;
-        const int  zeros     = overflow ? max_zeros : (width - zeros_threshold);
+        const int  zeros     = overflow ? max_zeros : width - zeros_threshold;
 
         encoded_count += zeros;
         for( ; encoded_count >= output_digits ; encoded_count -= output_digits )

--- a/src/golomb.h
+++ b/src/golomb.h
@@ -35,10 +35,11 @@ namespace pg::golomb
 
 namespace detail
 {
-template<typename InputIt>
+
+template< typename InputIt >
 concept integral_input_iterator = std::integral< typename std::iterator_traits< InputIt >::value_type > && std::input_iterator< InputIt >;
 
-template<typename InputIt>
+template< typename InputIt >
 concept unsigned_integral_input_iterator = std::unsigned_integral< typename std::iterator_traits< InputIt >::value_type > && std::input_iterator< InputIt >;
 
 template< std::signed_integral SignedT >
@@ -83,7 +84,7 @@ auto to_integral( std::unsigned_integral auto u )
 }
 
 template< typename OutputIt, std::unsigned_integral OutputDataT = uint8_t >
-requires std::output_iterator<OutputIt, OutputDataT>
+requires std::output_iterator< OutputIt, OutputDataT >
 class encoder
 {
     static constexpr auto output_digits = std::numeric_limits< OutputDataT >::digits;
@@ -192,7 +193,7 @@ public:
 template< std::unsigned_integral OutputDataT = uint8_t,
           detail::integral_input_iterator InputIt,
           typename OutputIt >
-requires std::output_iterator<OutputIt, OutputDataT>
+requires std::output_iterator< OutputIt, OutputDataT >
 constexpr auto encode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )
 {
     using ValueT = typename std::iterator_traits< InputIt >::value_type;
@@ -310,7 +311,7 @@ public:
 template< std::integral OutputValueT,
           detail::unsigned_integral_input_iterator InputIt,
           typename OutputIt >
-requires std::output_iterator<OutputIt , OutputValueT>
+requires std::output_iterator< OutputIt , OutputValueT >
 constexpr auto decode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )
 {
     decoder< OutputIt, OutputValueT > d( output, k );

--- a/src/golomb.h
+++ b/src/golomb.h
@@ -34,10 +34,10 @@ namespace pg::golomb
 {
 
 template<typename InputIt>
-concept integral_iterator = std::integral< typename std::iterator_traits< InputIt >::value_type >;
+concept integral_iterator = std::integral< typename std::iterator_traits< InputIt >::value_type > && std::input_iterator<InputIt>;
 
 template<typename InputIt>
-concept unsigned_integral_iterator = std::unsigned_integral< typename std::iterator_traits< InputIt >::value_type >;
+concept unsigned_integral_iterator = std::unsigned_integral< typename std::iterator_traits< InputIt >::value_type > && std::input_iterator<InputIt>;
 
 namespace detail
 {
@@ -84,6 +84,7 @@ auto to_integral( std::unsigned_integral auto u )
 }
 
 template< typename OutputIt, std::unsigned_integral OutputDataT = uint8_t >
+requires std::output_iterator<OutputIt, OutputDataT>
 class encoder
 {
     static constexpr auto output_digits = std::numeric_limits< OutputDataT >::digits;
@@ -192,6 +193,7 @@ public:
 template< std::unsigned_integral OutputDataT = uint8_t,
           integral_iterator InputIt,
           typename OutputIt >
+requires std::output_iterator<OutputIt, OutputDataT>
 constexpr auto encode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )
 {
     using ValueT = typename std::iterator_traits< InputIt >::value_type;
@@ -309,6 +311,7 @@ public:
 template< std::integral OutputValueT,
           unsigned_integral_iterator InputIt,
           typename OutputIt >
+requires std::output_iterator<OutputIt, OutputValueT>
 constexpr auto decode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )
 {
     decoder< OutputIt, OutputValueT > d( output, k );

--- a/src/golomb.h
+++ b/src/golomb.h
@@ -35,34 +35,11 @@ namespace pg::golomb
 
 namespace detail
 {
-    template<typename InputIt>
-    concept input_iterator_all_compilers = requires()
-    {
-        // Clang and GCC have a different implementation of std::input_iterator<typename>, which fails this concept while MSVC allows it.
-        // Workaround: use the less strict constraint std::input_or_output_iterator instead of std::input_iterator
-#ifdef _MSC_VER
-        requires std::input_iterator< InputIt >;
-#else
-        requires std::input_or_output_iterator< InputIt >;
-#endif
-    };
+template<typename InputIt>
+concept integral_input_iterator = std::integral< typename std::iterator_traits< InputIt >::value_type > && std::input_iterator< InputIt >;
 
 template<typename InputIt>
-concept integral_iterator = std::integral< typename std::iterator_traits< InputIt >::value_type > && input_iterator_all_compilers< InputIt >;
-
-template<typename InputIt>
-concept unsigned_integral_iterator = std::unsigned_integral< typename std::iterator_traits< InputIt >::value_type > && input_iterator_all_compilers< InputIt >;
-
-// Workaround: only use std::output_iterator for MSVC
-template<typename OutputIt, typename UnderlayingType>
-concept output_iterator_all_compilers = requires()
-{
-#ifdef _MSC_VER
-    requires std::output_iterator<OutputIt, UnderlayingType>;
-#else
-    requires true;// cannot use std::output_iterator or std::input_or_output_iterator since it won't allow backinserters.
-#endif
-};
+concept unsigned_integral_input_iterator = std::unsigned_integral< typename std::iterator_traits< InputIt >::value_type > && std::input_iterator< InputIt >;
 
 template< std::signed_integral SignedT >
 auto to_unsigned( SignedT s )
@@ -106,7 +83,7 @@ auto to_integral( std::unsigned_integral auto u )
 }
 
 template< typename OutputIt, std::unsigned_integral OutputDataT = uint8_t >
-requires pg::golomb::detail::output_iterator_all_compilers<OutputIt, OutputDataT>
+requires std::output_iterator<OutputIt, OutputDataT>
 class encoder
 {
     static constexpr auto output_digits = std::numeric_limits< OutputDataT >::digits;
@@ -213,9 +190,9 @@ public:
 };
 
 template< std::unsigned_integral OutputDataT = uint8_t,
-          pg::golomb::detail::integral_iterator InputIt,
+          pg::golomb::detail::integral_input_iterator InputIt,
           typename OutputIt >
-requires pg::golomb::detail::output_iterator_all_compilers<OutputIt, OutputDataT>
+requires std::output_iterator<OutputIt, OutputDataT>
 constexpr auto encode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )
 {
     using ValueT = typename std::iterator_traits< InputIt >::value_type;
@@ -331,9 +308,9 @@ public:
 };
 
 template< std::integral OutputValueT,
-          pg::golomb::detail::unsigned_integral_iterator InputIt,
+          pg::golomb::detail::unsigned_integral_input_iterator InputIt,
           typename OutputIt >
-requires pg::golomb::detail::output_iterator_all_compilers<OutputIt , OutputValueT>
+requires std::output_iterator<OutputIt , OutputValueT>
 constexpr auto decode( InputIt input, InputIt last, OutputIt output, size_t k = 0u )
 {
     decoder< OutputIt, OutputValueT > d( output, k );

--- a/util/golomb.cpp
+++ b/util/golomb.cpp
@@ -137,8 +137,8 @@ struct binary_input_file_iterator
         return !operator==( other );
     }
 
-    T &                          operator*()        { return value; }
-    const T &                    operator*()  const { return value; }
+    reference                    operator*()        { return value; }
+    const reference              operator*()  const { return value; }
     binary_input_file_iterator * operator->() const { return &value; }
     binary_input_file_iterator & operator++()       { next(); return *this; }
     binary_input_file_iterator   operator++( int )  { auto it = *this; next(); return it; }
@@ -181,6 +181,11 @@ struct binary_output_file_iterator
         : file( file )
     {}
 
+    binary_output_file_iterator(const binary_output_file_iterator& other)                   = default; // Copy ctor
+    binary_output_file_iterator& operator= (const binary_output_file_iterator& other)       = default; // Copy assignment
+    binary_output_file_iterator(binary_output_file_iterator&& other)             noexcept   = default; // Move ctor
+    binary_output_file_iterator& operator= (binary_output_file_iterator&& other) noexcept   = default; // Move ctor
+
     T operator=( T value )
     {
         assert( file );
@@ -213,7 +218,7 @@ struct binary_output_file_iterator
     binary_output_file_iterator   operator++( int ) { return *this; }
 
 private:
-    std::FILE * const file = nullptr;
+    std::FILE * file = nullptr;
 };
 
 

--- a/util/golomb.cpp
+++ b/util/golomb.cpp
@@ -137,9 +137,9 @@ struct binary_input_file_iterator
         return !operator==( other );
     }
 
-    reference                    operator*()        { return value; }
+    reference                    operator*() { return value; }
     const reference              operator*()  const { return value; }
-    binary_input_file_iterator * operator->() const { return &value; }
+    binary_input_file_iterator* operator->() const { return &value; }
     binary_input_file_iterator & operator++()       { next(); return *this; }
     binary_input_file_iterator   operator++( int )  { auto it = *this; next(); return it; }
 
@@ -180,11 +180,6 @@ struct binary_output_file_iterator
     binary_output_file_iterator( std::FILE * file = nullptr )
         : file( file )
     {}
-
-    binary_output_file_iterator(const binary_output_file_iterator& other)                   = default; // Copy ctor
-    binary_output_file_iterator& operator= (const binary_output_file_iterator& other)       = default; // Copy assignment
-    binary_output_file_iterator(binary_output_file_iterator&& other)             noexcept   = default; // Move ctor
-    binary_output_file_iterator& operator= (binary_output_file_iterator&& other) noexcept   = default; // Move ctor
 
     T operator=( T value )
     {

--- a/util/golomb.cpp
+++ b/util/golomb.cpp
@@ -137,9 +137,9 @@ struct binary_input_file_iterator
         return !operator==( other );
     }
 
-    reference                    operator*() { return value; }
+    reference                    operator*()        { return value; }
     const reference              operator*()  const { return value; }
-    binary_input_file_iterator* operator->() const { return &value; }
+    binary_input_file_iterator * operator->() const { return &value; }
     binary_input_file_iterator & operator++()       { next(); return *this; }
     binary_input_file_iterator   operator++( int )  { auto it = *this; next(); return it; }
 


### PR DESCRIPTION
-Add user concepts for easier use later
-Use concepts directly instead of typename T requires concept<T>
-Add extra checks on iterators (InputIt being an std::input_interator, OutputIt being an std::output_iterator of correct type)

Solves a part of #1, the OutputIt type being unspecified and unconstrained.